### PR TITLE
RailsInteractive::Templates - Rubocop 

### DIFF
--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -24,19 +24,11 @@ module RailsInteractive
     end
 
     def initialize_project
-      @inputs[:name] = Prompt.new("Enter the name of the project: ", "ask", required: true).perform
-
-      types = { "App" => "", "API" => "--api" }
-      @inputs[:type] = Prompt.new("Choose project type: ", "select", types, required: true).perform
-
-      database_types = { "PostgreSQL" => "-d postgresql", "MySQL" => "-d mysql", "SQLite" => "" }
-      @inputs[:database] = Prompt.new("Choose project's database: ", "select", database_types, required: true).perform
-
-      features = %w[devise cancancan omniauth pundit brakeman sidekiq]
-      @inputs[:features] = Prompt.new("Choose project features: ", "multi_select", features).perform
-
-      code_quality_tool = { "Rubocop" => "rubocop" }
-      @inputs[:code_quality_tool] = Prompt.new("Choose project code quality tool: ", "select", code_quality_tool).perform
+      name
+      type
+      database
+      features
+      code_quality_tool
 
       create
     end
@@ -74,6 +66,36 @@ module RailsInteractive
 
     def copy_templates_to_project
       FileUtils.cp_r "#{__dir__}/rails_interactive/templates", "./#{@inputs[:name]}"
+    end
+
+    private
+
+    def name
+      @inputs[:name] = Prompt.new("Enter the name of the project: ", "ask", required: true).perform
+    end
+
+    def type
+      types = { "App" => "", "API" => "--api" }
+      @inputs[:type] = Prompt.new("Choose project type: ", "select", types, required: true).perform
+    end
+
+    def database
+      database_types = { "PostgreSQL" => "-d postgresql", "MySQL" => "-d mysql", "SQLite" => "" }
+
+      @inputs[:database] = Prompt.new("Choose project's database: ", "select", database_types, required: true).perform
+    end
+
+    def features
+      features = %w[devise cancancan omniauth pundit brakeman sidekiq]
+
+      @inputs[:features] = Prompt.new("Choose project features: ", "multi_select", features).perform
+    end
+
+    def code_quality_tool
+      code_quality_tool = { "Rubocop" => "rubocop" }
+
+      @inputs[:code_quality_tool] =
+        Prompt.new("Choose project code quality tool: ", "select", code_quality_tool).perform
     end
   end
 end

--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -35,6 +35,9 @@ module RailsInteractive
       features = %w[devise cancancan omniauth pundit brakeman sidekiq]
       @inputs[:features] = Prompt.new("Choose project features: ", "multi_select", features).perform
 
+      code_quality_tool = { "Rubocop" => "rubocop" }
+      @inputs[:code_quality_tool] = Prompt.new("Choose project code quality tool: ", "select", code_quality_tool).perform
+
       create
     end
 
@@ -48,9 +51,13 @@ module RailsInteractive
 
       # Move to project folder and install gems
       Dir.chdir "./#{@inputs[:name]}"
+
       @inputs[:features].each do |feature|
         system("bin/rails app:template LOCATION=templates/setup_#{feature}.rb")
       end
+
+      # Code Quality Template
+      system("bin/rails app:template LOCATION=templates/setup_#{@inputs[:code_quality_tool]}.rb")
 
       # Prepare project requirements and give instructions
       Message.prepare
@@ -60,7 +67,7 @@ module RailsInteractive
       base = "rails new"
       cmd = ""
 
-      @inputs.each { |_key, value| cmd += "#{value} " }
+      @inputs.first(3).each { |_key, value| cmd += "#{value} " }
 
       "#{base} #{cmd}".strip!
     end

--- a/lib/rails_interactive/templates/setup_rubocop.rb
+++ b/lib/rails_interactive/templates/setup_rubocop.rb
@@ -7,3 +7,4 @@ end
 Bundler.with_unbundled_env { run 'bundle install' }
 
 run "rubocop --auto-gen-config"
+run "bundle binstubs rubocop"

--- a/lib/rails_interactive/templates/setup_rubocop.rb
+++ b/lib/rails_interactive/templates/setup_rubocop.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+gem_group :development do
+  gem 'rubocop', require: false
+end
+
+Bundler.with_unbundled_env { run 'bundle install' }
+
+run "rubocop --auto-gen-config"

--- a/lib/rails_interactive/templates/setup_rubocop.rb
+++ b/lib/rails_interactive/templates/setup_rubocop.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 gem_group :development do
-  gem 'rubocop', require: false
+  gem "rubocop", require: false
 end
 
-Bundler.with_unbundled_env { run 'bundle install' }
+Bundler.with_unbundled_env { run "bundle install" }
 
 run "rubocop --auto-gen-config"
 run "bundle binstubs rubocop"


### PR DESCRIPTION
## What's up?
In this PR, Rails interactive have Rubocop integration. In this way, when users select Rubocop to install their rails project, CLI will install Rubocop to the related project with the use of rails templates