### PR TITLE
RailsInteractive::Templates - RailsAdmin

### DIFF
--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -29,6 +29,7 @@ module RailsInteractive
       database
       features
       code_quality_tool
+      admin_panel
 
       create
     end
@@ -50,6 +51,9 @@ module RailsInteractive
 
       # Code Quality Template
       system("bin/rails app:template LOCATION=templates/setup_#{@inputs[:code_quality_tool]}.rb")
+
+      # Admin Panel Template
+      system("bin/rails app:template LOCATION=templates/setup_#{@inputs[:admin_panel]}.rb")
 
       # Prepare project requirements and give instructions
       Message.prepare
@@ -96,6 +100,13 @@ module RailsInteractive
 
       @inputs[:code_quality_tool] =
         Prompt.new("Choose project code quality tool: ", "select", code_quality_tool).perform
+    end
+
+    def admin_panel
+      admin_panel = { "RailsAdmin" => "rails_admin" }
+
+      @inputs[:admin_panel] =
+        Prompt.new("Choose project admin panel: ", "select", admin_panel).perform
     end
   end
 end

--- a/lib/rails_interactive/templates/setup_rails_admin.rb
+++ b/lib/rails_interactive/templates/setup_rails_admin.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+run "rails db:prepare"
 run "bundle add rails_admin"
 
 Bundler.with_unbundled_env { run "bundle install" }

--- a/lib/rails_interactive/templates/setup_rails_admin.rb
+++ b/lib/rails_interactive/templates/setup_rails_admin.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+run "bundle add rails_admin"
+
+Bundler.with_unbundled_env { run "bundle install" }
+
+rails_command("generate rails_admin:install")
+
+puts "RailsAdmin is installed! You can go to your admin panel at /admin"


### PR DESCRIPTION
## What's up?
In this PR, Rails interactive have RailsAdmin integration. In this way, when users select RailsAdmin to install their rails project, CLI will install RailsAdmin to the related project with the use of rails templates

Related Issue : https://github.com/oguzsh/rails-interactive/issues/11