### PR TITLE
RailsInteractive::Templates - Avo 

### DIFF
--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -103,10 +103,10 @@ module RailsInteractive
     end
 
     def admin_panel
-      admin_panel = { "RailsAdmin" => "rails_admin" }
+      admin_panel = { "RailsAdmin" => "rails_admin", "Avo" => "avo" }
 
       @inputs[:admin_panel] =
-        Prompt.new("Choose project admin panel: ", "select", admin_panel).perform
+        Prompt.new("Choose project's admin panel: ", "select", admin_panel).perform
     end
   end
 end

--- a/lib/rails_interactive/templates/setup_avo.rb
+++ b/lib/rails_interactive/templates/setup_avo.rb
@@ -7,4 +7,4 @@ Bundler.with_unbundled_env { run "bundle install" }
 
 rails_command("generate avo:install")
 
-puts "Avo is installed! You can go to https://docs.avohq.io/2.0/resources.html for next steps"
+puts "Avo is installed! You can go to http://localhost:3000/avo for next steps"

--- a/lib/rails_interactive/templates/setup_avo.rb
+++ b/lib/rails_interactive/templates/setup_avo.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+run "rails db:prepare"
+run "bundle add avo"
+
+Bundler.with_unbundled_env { run "bundle install" }
+
+rails_command("generate avo:install")
+
+puts "Avo is installed! You can go to https://docs.avohq.io/2.0/resources.html for next steps"


### PR DESCRIPTION
## What's up?
In this PR, Rails interactive have [Avo](https://avohq.io/) integration. In this way, when users select [Avo](https://avohq.io/) to install their rails project, CLI will install [Avo](https://avohq.io/) to the related project with the use of rails templates

Related Issue : https://github.com/oguzsh/rails-interactive/issues/11