### PR TITLE
RailsInteractive::Templates - RSpec

### DIFF
--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -45,9 +45,8 @@ module RailsInteractive
       # Move to project folder and install gems
       Dir.chdir "./#{@inputs[:name]}"
 
-      @inputs[:features].each do |feature|
-        system("bin/rails app:template LOCATION=templates/setup_#{feature}.rb")
-      end
+      # Features Templates
+      handle_multi_options(key: :features)
 
       # Code Quality Template
       system("bin/rails app:template LOCATION=templates/setup_#{@inputs[:code_quality_tool]}.rb")
@@ -73,6 +72,12 @@ module RailsInteractive
     end
 
     private
+
+    def handle_multi_options(key:)
+      @inputs[key].each do |value|
+        system("bin/rails app:template LOCATION=templates/setup_#{value}.rb")
+      end
+    end
 
     def name
       @inputs[:name] = Prompt.new("Enter the name of the project: ", "ask", required: true).perform

--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -30,6 +30,7 @@ module RailsInteractive
       features
       code_quality_tool
       admin_panel
+      testing_tools
 
       create
     end
@@ -53,6 +54,9 @@ module RailsInteractive
 
       # Admin Panel Template
       system("bin/rails app:template LOCATION=templates/setup_#{@inputs[:admin_panel]}.rb")
+
+      # Testing tools Template
+      handle_multi_options(key: :testing_tools)
 
       # Prepare project requirements and give instructions
       Message.prepare
@@ -112,6 +116,13 @@ module RailsInteractive
 
       @inputs[:admin_panel] =
         Prompt.new("Choose project's admin panel: ", "select", admin_panel).perform
+    end
+
+    def testing_tools
+      testing_tools = %w[rspec]
+
+      @inputs[:testing_tools] =
+        Prompt.new("Choose project's testing tools: ", "multi_select", testing_tools).perform
     end
   end
 end

--- a/lib/rails_interactive/templates/setup_rspec.rb
+++ b/lib/rails_interactive/templates/setup_rspec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 run "spring stop"
 
 gem_group :development, :test do

--- a/lib/rails_interactive/templates/setup_rspec.rb
+++ b/lib/rails_interactive/templates/setup_rspec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+run "spring stop"
+
+gem_group :development, :test do
+  gem "rspec-rails"
+end
+
+Bundler.with_unbundled_env { run "bundle install" }
+
+rails_command "generate rspec:install"
+
+puts "RSpec is installed!"


### PR DESCRIPTION
## What's up?
In this PR, Rails interactive have RSpec integration. In this way, when users select RSpec to install their rails project, CLI will install RSpec to the related project with the use of rails templates

Related Issue: https://github.com/oguzsh/rails-interactive/issues/9