### PR TITLE
RailsInteractive::Templates - GraphQL

### DIFF
--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -99,7 +99,7 @@ module RailsInteractive
     end
 
     def features
-      features = %w[devise cancancan omniauth pundit brakeman sidekiq]
+      features = %w[devise cancancan omniauth pundit brakeman sidekiq graphql]
 
       @inputs[:features] = Prompt.new("Choose project features: ", "multi_select", features).perform
     end

--- a/lib/rails_interactive/templates/setup_graphql.rb
+++ b/lib/rails_interactive/templates/setup_graphql.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+run "rails db:prepare"
+run "bundle add graphql"
+
+Bundler.with_unbundled_env { run "bundle install" }
+
+rails_command("generate graphql:install")
+
+puts "GraphQL is installed!"


### PR DESCRIPTION
## What's up?

In this PR, Rails interactive have GraphQL integration. In this way, when users select GraphQL to install their rails project, CLI will install GraphQL to the related project with the use of rails templates

Related PR: https://github.com/oguzsh/rails-interactive/issues/15