### PR TITLE
RailsInteractive::Templates - Kaminari

### DIFF
--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -99,7 +99,7 @@ module RailsInteractive
     end
 
     def features
-      features = %w[devise cancancan omniauth pundit brakeman sidekiq graphql]
+      features = %w[devise cancancan omniauth pundit brakeman sidekiq graphql kaminari]
 
       @inputs[:features] = Prompt.new("Choose project features: ", "multi_select", features).perform
     end

--- a/lib/rails_interactive/templates/setup_kaminari.rb
+++ b/lib/rails_interactive/templates/setup_kaminari.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+run "bundle add kaminari"
+
+Bundler.with_unbundled_env { run "bundle install" }
+
+puts "Kaminari is installed!"


### PR DESCRIPTION
## What's up?

In this PR, Rails interactive have Kaminari integration. In this way, when users select Kaminari to install their rails project, CLI will install Kaminari to the related project with the use of rails templates

Related PR: https://github.com/oguzsh/rails-interactive/issues/15