### PR TITLE
RailsInteractive::Templates - HAML

### DIFF
--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -29,6 +29,7 @@ module RailsInteractive
       database
       features
       code_quality_tool
+      template_engines
       admin_panel
       testing_tools
 
@@ -51,6 +52,9 @@ module RailsInteractive
 
       # Code Quality Template
       system("bin/rails app:template LOCATION=templates/setup_#{@inputs[:code_quality_tool]}.rb")
+
+      # HTML Template Engines
+      system("bin/rails app:template LOCATION=templates/setup_#{@inputs[:template_engine]}.rb")
 
       # Admin Panel Template
       system("bin/rails app:template LOCATION=templates/setup_#{@inputs[:admin_panel]}.rb")
@@ -123,6 +127,13 @@ module RailsInteractive
 
       @inputs[:testing_tools] =
         Prompt.new("Choose project's testing tools: ", "multi_select", testing_tools).perform
+    end
+
+    def template_engines
+      template_engines = { "HAML" => "haml" }
+
+      @inputs[:template_engine] =
+        Prompt.new("Choose project's template engine: ", "select", template_engines).perform
     end
   end
 end

--- a/lib/rails_interactive/templates/setup_haml.rb
+++ b/lib/rails_interactive/templates/setup_haml.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+def bundle_install
+  Bundler.with_unbundled_env { run "bundle install" }
+end
+
+run "bundle add haml"
+bundle_install
+
+if yes?("Would you like to convert your existing *.erb files to *.haml files? [y/n]")
+  run "bundle add erb2haml --group 'development'"
+  bundle_install
+  if yes?("Would you like to keep the original *.erb files? [y/n]")
+    rake "haml:convert_erbs"
+  else
+    rake "haml:replace_erbs"
+  end
+end


### PR DESCRIPTION
## What's up?
In this PR, Rails interactive have HAML integration. In this way, when users select HAML to install their rails project, CLI will install HAML to the related project with the use of rails templates

Related PR: https://github.com/oguzsh/rails-interactive/issues/15