### PR TITLE
RailsInteractive::Templates - Slim Html

### DIFF
--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -130,7 +130,7 @@ module RailsInteractive
     end
 
     def template_engines
-      template_engines = { "HAML" => "haml" }
+      template_engines = { "HAML" => "haml", "SLIM" => "slim" }
 
       @inputs[:template_engine] =
         Prompt.new("Choose project's template engine: ", "select", template_engines).perform

--- a/lib/rails_interactive/templates/setup_slim.rb
+++ b/lib/rails_interactive/templates/setup_slim.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+def bundle_install
+  Bundler.with_unbundled_env { run "bundle install" }
+end
+
+run "bundle add slim-rails"
+
+bundle_install
+
+if yes?("Would you like to convert your existing *.erb files to *.slim files? [y/n]")
+  run "bundle add html2slim --group 'development'"
+  bundle_install
+  if yes?("Would you like to keep the original *.erb files? [y/n]")
+    run "erb2slim app/views"
+  else
+    run "erb2slim app/views -d"
+  end
+end


### PR DESCRIPTION
## What's up?
In this PR, Rails interactive have Slim Html integration. In this way, when users select Slim Html to install their rails project, CLI will install Slim Html to the related project with the use of rails templates

Related Issue : #15 