### PR TITLE
RailsInteractive::Templates - Friendly Id

### DIFF
--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -143,7 +143,7 @@ module RailsInteractive
     end
 
     def development_tools
-      development_tools = %w[bullet faker]
+      development_tools = %w[bullet faker friendly_id]
 
       @inputs[:development_tools] =
         Prompt.new("Choose project's development tools: ", "multi_select", development_tools).perform

--- a/lib/rails_interactive/templates/setup_friendly_id.rb
+++ b/lib/rails_interactive/templates/setup_friendly_id.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+def ask_with_default(prompt, default)
+  value = ask("#{prompt} (default: #{default})")
+  value.present? ? value : default
+end
+
+run "bundle add 'friendly_id'"
+
+rails_command "generate friendly_id"
+
+while yes?("Do you want to use Friendly ID with an existing model? (y/n)")
+  model_name = ask_with_default("Model Name:", "Postr")
+  attribute = ask_with_default("Attribute:", "name")
+  next unless model_name && attribute
+
+  # We generate a migration to add the friendly id slug column.
+  generate(:migration, "AddSlugTo#{model_name.titleize.pluralize}", "slug:uniq")
+  string = <<~RUBY
+    extend FriendlyId
+    friendly_id :#{attribute}, use: :slugged
+  RUBY
+  # Inject the friendly id methods into the class.
+  inject_into_file "app/models/#{model_name.downcase}.rb", string,
+                   after: "class #{model_name.titleize} < ApplicationRecord\n"
+end


### PR DESCRIPTION
## What's up?
In this PR, Rails interactive have Friendly Id integration. In this way, when users select Friendly Id to install their rails project, CLI will install Friendly Id to the related project with the use of rails templates

Related Issue: #15 