### PR TITLE
RailsInteractive::Templates - BetterErrors

### DIFF
--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -143,7 +143,7 @@ module RailsInteractive
     end
 
     def development_tools
-      development_tools = %w[bullet faker friendly_id]
+      development_tools = %w[bullet faker friendly_id better_errors]
 
       @inputs[:development_tools] =
         Prompt.new("Choose project's development tools: ", "multi_select", development_tools).perform

--- a/lib/rails_interactive/templates/setup_better_errors.rb
+++ b/lib/rails_interactive/templates/setup_better_errors.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+gem_group :development do
+  gem "better_errors"
+  gem "binding_of_caller"
+end
+
+Bundler.with_unbundled_env { run "bundle install" }


### PR DESCRIPTION
## What's up?
In this PR, Rails interactive have BetterErrors integration. In this way, when users select BetterErrors to install their rails project, CLI will install BetterErrors to the related project with the use of rails templates

Related Issue: https://github.com/oguzsh/rails-interactive/issues/15