### PR TITLE
RailsInteractive::CommandHandler - Duplicate Dependency Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mkmf.log
 *.gem
 # rspec failure tracking
 .rspec_status
+.idea

--- a/lib/cli/command_handler.rb
+++ b/lib/cli/command_handler.rb
@@ -9,23 +9,41 @@ module RailsInteractive
     class CommandHandler
       def initialize
         @commands = Command.new.all
+        @installed_commands = []
+        @installed_dependencies = []
       end
 
       def handle_multi_options(options, dependencies = nil)
         handle_dependencies(dependencies)
-        options.each { |option| system("bin/rails app:template LOCATION=templates/setup_#{option}.rb") }
+
+        options.each do |option|
+          @installed_commands << option
+          system("bin/rails app:template LOCATION=templates/setup_#{option}.rb")
+        end
       end
 
       def handle_option(option, dependencies = nil)
+        @installed_commands << option
         handle_dependencies(dependencies)
+
         system("bin/rails app:template LOCATION=templates/setup_#{option}.rb")
       end
 
       def handle_dependencies(dependencies)
         dependencies&.each do |dependency|
+          next if duplicated_gem?(dependency)
+
           puts ">> Dependency Detected: #{dependency} "
+          @installed_dependencies << dependency
+
           system("bin/rails app:template LOCATION=templates/setup_#{dependency}.rb")
         end
+      end
+
+      private
+
+      def duplicated_gem?(option)
+        @installed_commands.include?(option) || @installed_dependencies.include?(option)
       end
     end
   end


### PR DESCRIPTION
## What's up ?
In this PR, we have added a duplicate dependency check. In this way, CLI doesn't install the same gem again.

Closes #77 