### PR TITLE
RailsInteractive::Templates - Capybara

### DIFF
--- a/lib/cli/config/categories.yml
+++ b/lib/cli/config/categories.yml
@@ -15,37 +15,42 @@
     type: "select"
     required: false
 -
-    name: template_engine
+    name: end_to_end_testing
     weight: 4
     type: "select"
     required: false
 -
-    name: code_quality
+    name: template_engine
     weight: 5
     type: "select"
     required: false
 -
-    name: background_job
+    name: code_quality
     weight: 6
     type: "select"
     required: false
 -
-    name: security
+    name: background_job
     weight: 7
     type: "select"
     required: false
 -
-    name: admin_panel
+    name: security
     weight: 8
     type: "select"
     required: false
 -
-    name: features
+    name: admin_panel
     weight: 9
+    type: "select"
+    required: false
+-
+    name: features
+    weight: 10
     type: "multi_select"
     required: false
 -
     name: development
-    weight: 10
+    weight: 11
     type: "multi_select"
     required: false

--- a/lib/cli/config/commands.yml
+++ b/lib/cli/config/commands.yml
@@ -146,3 +146,9 @@
   category: testing
   description: "minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking. For details: https://github.com/minitest/minitest"
   dependencies: null
+-
+  identifier: capybara
+  name: Capybara
+  category: end_to_end_testing
+  description: "Acceptance test framework for web applications. For details: https://github.com/teamcapybara/capybara"
+  dependencies: null

--- a/lib/cli/templates/setup_capybara.rb
+++ b/lib/cli/templates/setup_capybara.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+gem_group :development, :test do
+  gem "capybara"
+end
+
+Bundler.with_unbundled_env { run "bundle install" }
+
+if defined? RSpec
+  inject_into_file "spec/spec_helper.rb", before: "RSpec.configure do |config|" do
+    <<~RB
+      require 'capybara/rspec'
+    RB
+  end
+elsif defined? MiniTest && !defined? RSpec
+  inject_into_file "test/test_helper.rb", before: "class ActiveSupport::TestCase" do
+    <<~RB
+      require 'capybara/rails'
+      require 'capybara/minitest'
+    RB
+  end
+else
+  puts "No test framework detected or related test framework does not exist in RailsInteractive"
+end


### PR DESCRIPTION
## What's up?
In this PR, Rails interactive have Capybara integration. In this way, when users select Capybara to install their rails project, CLI will install Capybara to the related project with the use of rails templates

Closes #9 