### PR TITLE
RailsInteractive::Templates - StimulusJS

### DIFF
--- a/lib/cli/config/categories.yml
+++ b/lib/cli/config/categories.yml
@@ -25,7 +25,7 @@
     type: "select"
     required: false
 -
-    name: code_quality
+    name: frontend
     weight: 6
     type: "select"
     required: false
@@ -35,22 +35,27 @@
     type: "select"
     required: false
 -
-    name: security
+    name: code_quality
     weight: 8
     type: "select"
     required: false
 -
-    name: admin_panel
+    name: security
     weight: 9
     type: "select"
     required: false
 -
-    name: features
+    name: admin_panel
     weight: 10
+    type: "select"
+    required: false
+-
+    name: features
+    weight: 11
     type: "multi_select"
     required: false
 -
     name: development
-    weight: 11
+    weight: 12
     type: "multi_select"
     required: false

--- a/lib/cli/config/commands.yml
+++ b/lib/cli/config/commands.yml
@@ -152,3 +152,9 @@
   category: end_to_end_testing
   description: "Acceptance test framework for web applications. For details: https://github.com/teamcapybara/capybara"
   dependencies: null
+-
+  identifier: stimulus
+  name: StimulusJS
+  category: frontend
+  description: "A modest JavaScript framework for the HTML you already have. For details: https://github.com/hotwired/stimulus"
+  dependencies: null

--- a/lib/cli/templates/setup_stimulus.rb
+++ b/lib/cli/templates/setup_stimulus.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+run "bundle add turbo-rails"
+run "bundle add stimulus-rails"
+
+Bundler.with_unbundled_env { run "bundle install" }
+
+rails_command "turbo:install stimulus:install"

--- a/lib/rails_interactive.rb
+++ b/lib/rails_interactive.rb
@@ -63,7 +63,7 @@ module RailsInteractive
 
       @inputs.first(3).each { |_key, value| cmd += "#{value} " unless value.empty? }
 
-      "#{base} #{cmd} -q"
+      "#{base} #{cmd} -q --skip-hotwire"
     end
 
     def create_project


### PR DESCRIPTION
## What's up?
In this PR, Rails interactive have StimulusJS integration. In this way, when users select StimulusJS to install their rails project, CLI will install StimulusJS to the related project with the use of rails templates

## Related PRs
#8 